### PR TITLE
import sys fix

### DIFF
--- a/onefibersimulation.py
+++ b/onefibersimulation.py
@@ -3,6 +3,7 @@ import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as pyplot
 import math
+import sys
 #neuron.load_mechanisms("./mod")
 from cfiber import cfiber
 


### PR DESCRIPTION
Fixes a bug where `numofmodel` is based on `sys.argv[3]` but `sys` was not defined, causing the program to exit prematurely.